### PR TITLE
Add generation source confirmation

### DIFF
--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/domain/service/PipelineStepsFactoryService.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/domain/service/PipelineStepsFactoryService.kt
@@ -17,6 +17,8 @@ internal interface PipelineStepsFactoryService {
 
     fun prepareGenerationSourceCode(): PipelineStep<FunctionTestDependencies, CodeBlock>
 
+    fun confirmGenerationSource(): PipelineStep<CodeBlock, CodeBlock>
+
     fun generateCodeSuggestion(): PipelineStep<CodeBlock, GenerateCodeBlockResult>
 
     fun replaceFunctionBody(function: KtNamedFunction): PipelineStep<GenerateCodeBlockResult, KtNamedFunction>

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/action/CodeGenerateAction.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/action/CodeGenerateAction.kt
@@ -89,6 +89,7 @@ class CodeGenerateAction : AnAction() {
 
         pipeline.collectTestsAndUsedReferencesForFun(targetFunction, targetClass, testClass)
             .andThen(pipeline.prepareGenerationSourceCode())
+            .andThen(pipeline.confirmGenerationSource())
             .andThen(
                 pipeline.generateCodeSuggestion()
                     .andThen(pipeline.replaceFunctionBody(targetFunction))

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifyGenerationSourceDialog.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifyGenerationSourceDialog.kt
@@ -1,0 +1,49 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog
+
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.panel
+import java.awt.Dimension
+import javax.swing.Action
+import javax.swing.JComponent
+
+internal class ModifyGenerationSourceDialog : DialogWrapper(true) {
+
+    private val codeTextArea = JBTextArea().apply {
+        name = "codeArea"
+    }
+
+    init {
+        title = "Confirm Source"
+        init()
+    }
+
+    override fun getDimensionServiceKey(): String {
+        return "dev.sunnyday.fusiontdd.fusiontddplugin.ConfirmGenerationSourceDialog"
+    }
+
+    fun setCodeBlock(rawCode: String) {
+        codeTextArea.text = rawCode
+    }
+
+    fun getCodeBlock(): String {
+        return codeTextArea.text
+    }
+
+    override fun createCenterPanel(): JComponent {
+        return panel {
+            row { label("This source will be used for generation:") }
+            row {
+                cell(JBScrollPane(codeTextArea))
+                    .applyToComponent { preferredSize = Dimension(800, 600) }
+                    .align(Align.FILL)
+            }
+        }
+    }
+
+    override fun createActions(): Array<Action> {
+        return arrayOf(cancelAction, okAction)
+    }
+}

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryService.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryService.kt
@@ -8,10 +8,7 @@ import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.FunctionTestDependenc
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.GenerateCodeBlockResult
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.service.PipelineStepsFactoryService
 import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.PipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.CollectTestsAndUsedReferencesForFunPipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.GenerateCodeSuggestionsPipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.PrepareGenerationSourceCodePipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.ReplaceFunctionBodyPipelineStep
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.*
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
@@ -35,6 +32,12 @@ internal class ProjectPipelineStepsFactoryService(
 
     override fun prepareGenerationSourceCode(): PipelineStep<FunctionTestDependencies, CodeBlock> {
         return PrepareGenerationSourceCodePipelineStep(
+            settings = project.service(),
+        )
+    }
+
+    override fun confirmGenerationSource(): PipelineStep<CodeBlock, CodeBlock> {
+        return ConfirmGenerationSourcePipelineStep(
             settings = project.service(),
         )
     }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettings.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettings.kt
@@ -24,6 +24,8 @@ internal class FusionTDDSettings : SimplePersistentStateComponent<FusionTDDSetti
     var starcoderUseCache by state::starcoderUseCache
 
     var starcoderWaitForModel by state::starcoderWaitForModel
+
+    var isConfirmSourceBeforeGeneration by state::isConfirmSourceBeforeGeneration
 }
 
 internal class FusionTDDSettingsState : BaseState() {
@@ -45,4 +47,6 @@ internal class FusionTDDSettingsState : BaseState() {
     var starcoderUseCache by property(false)
 
     var starcoderWaitForModel by property(true)
+
+    var isConfirmSourceBeforeGeneration by property(false)
 }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProvider.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProvider.kt
@@ -28,23 +28,16 @@ internal class FusionTTDSettingsConfigurable(
         return panel {
             group("Project Config") {
                 row {
-                    textField()
+                    passwordField()
+                        .applyToComponent { name = settings::authToken.name }
                         .label("Starcoder auth token")
                         .align(Align.FILL)
-                        .bindText(
-                            getter = { "**********" },
-                            setter = { tokenValue ->
-                                when {
-                                    tokenValue == "**********" -> Unit
-                                    tokenValue.isBlank() -> settings.authToken = null
-                                    else -> settings.authToken = tokenValue
-                                }
-                            }
-                        )
+                        .bindText(settings::authToken.orEmpty(), settings::authToken::set)
                 }
 
                 row {
                     textField()
+                        .applyToComponent { name = settings::projectPackage.name }
                         .label("Project package")
                         .align(Align.FILL)
                         .bindText(settings::projectPackage.orEmpty(), settings::projectPackage::set)
@@ -54,6 +47,7 @@ internal class FusionTTDSettingsConfigurable(
             group("Starcoder Config") {
                 row {
                     textField()
+                        .applyToComponent { name = settings::starcoderModel.name }
                         .label("Model")
                         .align(Align.FILL)
                         .bindText(settings::starcoderModel.orEmpty(), settings::starcoderModel::set)
@@ -61,6 +55,7 @@ internal class FusionTTDSettingsConfigurable(
 
                 row {
                     slider(0, 500, 50, 100)
+                        .applyToComponent { name = settings::starcoderMaxNewTokens.name }
                         .label("Max new tokens")
                         .showValueHint()
                         .comment(
@@ -76,6 +71,7 @@ internal class FusionTTDSettingsConfigurable(
                 row {
                     val temperatureFormat = DecimalFormat("#.##")
                     textField()
+                        .applyToComponent { name = settings::starcoderTemperature.name }
                         .label("Temperature")
                         .validationOnInput { field ->
                             val parseResult = runCatching { temperatureFormat.parse(field.text) }
@@ -94,12 +90,13 @@ internal class FusionTTDSettingsConfigurable(
                         .align(Align.FILL)
                         .bindText(
                             getter = { temperatureFormat.format(settings.starcoderTemperature) },
-                            setter = { temperatureFormat.parse(it).toFloat() }
+                            setter = { settings.starcoderTemperature = temperatureFormat.parse(it).toFloat() }
                         )
                 }
 
                 row {
                     checkBox("Do sample")
+                        .applyToComponent { name = settings::starcoderDoSample.name }
                         .comment(
                             comment = "Whether or not to use sampling, use greedy decoding otherwise.",
                         )
@@ -108,6 +105,7 @@ internal class FusionTTDSettingsConfigurable(
 
                 row {
                     checkBox("Use cache")
+                        .applyToComponent { name = settings::starcoderUseCache.name }
                         .comment(
                             comment = "There is a cache layer on the inference API " +
                                     "to speedup requests we have already seen. " +
@@ -122,6 +120,7 @@ internal class FusionTTDSettingsConfigurable(
 
                 row {
                     checkBox("Wait for model")
+                        .applyToComponent { name = settings::starcoderWaitForModel.name }
                         .comment(
                             comment = "If the model is not ready, wait for it instead of receiving 503. " +
                                     "It limits the number of requests required to get your inference done. " +
@@ -133,11 +132,24 @@ internal class FusionTTDSettingsConfigurable(
 
                 row {
                     checkBox("Add tests comments before generation")
+                        .applyToComponent { name = settings::isAddTestCommentsBeforeGeneration.name }
                         .comment(
                             comment = "If enabled, all used tests names will be collected " +
                                     "and places as a comment before the generating function.",
                         )
                         .bindSelected(settings::isAddTestCommentsBeforeGeneration)
+                }
+            }
+
+            group("Developer Settings") {
+                row {
+                    checkBox("Confirm generation source before request")
+                        .applyToComponent { name = settings::isConfirmSourceBeforeGeneration.name }
+                        .comment(
+                            comment = "If enabled, the source will be displayed for viewing and editing " +
+                                    "before sending a request to generate the result.",
+                        )
+                        .bindSelected(settings::isConfirmSourceBeforeGeneration)
                 }
             }
         }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/PipelineStep.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/PipelineStep.kt
@@ -1,6 +1,7 @@
 package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline
 
 import com.intellij.openapi.Disposable
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
 import java.util.concurrent.atomic.AtomicInteger
 
 internal fun interface PipelineStep<in Input, out Output> {
@@ -32,6 +33,7 @@ internal fun <Input, Output> PipelineStep<Input, Output>.retry(times: Int): Pipe
 
             override fun invoke(result: Result<Output>) {
                 when {
+                    result.exceptionOrNull() is PipelineCancellationException -> observer.invoke(result)
                     result.isSuccess -> observer.invoke(result)
                     counter.getAndIncrement() < times -> execute(input, this)
                     else -> observer.invoke(result)

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStep.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStep.kt
@@ -1,0 +1,29 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps
+
+import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.CodeBlock
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifyGenerationSourceDialog
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings.FusionTDDSettings
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.PipelineStep
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
+
+internal class ConfirmGenerationSourcePipelineStep(
+    private val settings: FusionTDDSettings,
+) : PipelineStep<CodeBlock, CodeBlock> {
+
+    override fun execute(input: CodeBlock, observer: (Result<CodeBlock>) -> Unit) {
+        if (!settings.isConfirmSourceBeforeGeneration) {
+            observer.invoke(Result.success(input))
+        } else {
+            val confirmDialog = ModifyGenerationSourceDialog().apply {
+                setCodeBlock(input.rawText)
+            }
+
+            if (confirmDialog.showAndGet()) {
+                val confirmedCodeBlock = CodeBlock(confirmDialog.getCodeBlock())
+                observer.invoke(Result.success(confirmedCodeBlock))
+            } else {
+                observer.invoke(Result.failure(PipelineCancellationException()))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/util/PipelineCancellationException.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/util/PipelineCancellationException.kt
@@ -1,0 +1,3 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util
+
+internal class PipelineCancellationException : Throwable()

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifyGenerationSourceDialogTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifyGenerationSourceDialogTest.kt
@@ -1,0 +1,75 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.DialogWrapperPeer
+import com.intellij.openapi.ui.DialogWrapperPeerFactory
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import com.intellij.testFramework.replaceService
+import com.intellij.testFramework.runInEdtAndWait
+import com.intellij.ui.components.JBTextArea
+import com.intellij.util.application
+import dev.sunnyday.fusiontdd.fusiontddplugin.test.requireChildByName
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.spyk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import javax.swing.JComponent
+import kotlin.properties.Delegates
+
+class ModifyGenerationSourceDialogTest : LightJavaCodeInsightFixtureTestCase5() {
+
+    private val contentPaneSlot = CapturingSlot<JComponent>()
+    private var originalPeerFactory: DialogWrapperPeerFactory by Delegates.notNull()
+
+    override fun getTestDataPath(): String = "testdata"
+
+    @BeforeEach
+    fun setUp() {
+        originalPeerFactory = application.service<DialogWrapperPeerFactory>()
+
+        val peerFactory = spyk(originalPeerFactory)
+        every { peerFactory.createPeer(any<DialogWrapper>(), any<Project>(), any(), any()) } answers {
+            spyk(invocation.originalCall.invoke() as DialogWrapperPeer) {
+                every { setContentPane(capture(contentPaneSlot)) } answers { invocation.originalCall.invoke() }
+            }
+        }
+
+        application.replaceService(
+            serviceInterface = DialogWrapperPeerFactory::class.java,
+            instance = peerFactory,
+            parentDisposable = { }
+        )
+    }
+
+    @Test
+    fun `dialog has dimensions service key`() = runInEdtAndWait {
+        val dialog = ModifyGenerationSourceDialog()
+        assertThat(dialog.dimensionKey).isNotEmpty()
+    }
+
+    @Test
+    fun `on set code block, fill code area`() = runInEdtAndWait {
+        val dialog = ModifyGenerationSourceDialog()
+        dialog.setCodeBlock(rawCode = "2 + 2")
+
+        val textArea = contentPaneSlot.captured.requireChildByName<JBTextArea>("codeArea")
+
+        assertThat(textArea.text).isEqualTo("2 + 2")
+    }
+
+
+    @Test
+    fun `on get code block, get it from code area`() = runInEdtAndWait {
+        val dialog = ModifyGenerationSourceDialog()
+        dialog.setCodeBlock(rawCode = "2 + 2")
+
+        val textArea = contentPaneSlot.captured.requireChildByName<JBTextArea>("codeArea")
+        textArea.text = "2 * 2"
+
+        assertThat(dialog.getCodeBlock()).isEqualTo("2 * 2")
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryServiceTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryServiceTest.kt
@@ -4,10 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
 import com.intellij.testFramework.registerServiceInstance
 import dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings.FusionTDDSettings
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.CollectTestsAndUsedReferencesForFunPipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.GenerateCodeSuggestionsPipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.PrepareGenerationSourceCodePipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.ReplaceFunctionBodyPipelineStep
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.*
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -38,6 +35,13 @@ class ProjectPipelineStepsFactoryServiceTest : LightJavaCodeInsightFixtureTestCa
         val actualStep = provider.prepareGenerationSourceCode()
 
         assertThat(actualStep).isInstanceOf(PrepareGenerationSourceCodePipelineStep::class.java)
+    }
+
+    @Test
+    fun `create step for confirmGenerationSource`() {
+        val actualStep = provider.confirmGenerationSource()
+
+        assertThat(actualStep).isInstanceOf(ConfirmGenerationSourcePipelineStep::class.java)
     }
 
     @Test

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProviderTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProviderTest.kt
@@ -1,0 +1,161 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import com.intellij.testFramework.registerServiceInstance
+import dev.sunnyday.fusiontdd.fusiontddplugin.test.requireChildByName
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import javax.swing.JCheckBox
+import javax.swing.JSlider
+import javax.swing.JTextField
+
+class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTestCase5() {
+
+    private val settings = mockk<FusionTDDSettings>(relaxed = true)
+
+    override fun getTestDataPath(): String = "testdata"
+
+    @BeforeEach
+    fun setUp() {
+        fixture.project.registerServiceInstance(FusionTDDSettings::class.java, settings)
+    }
+
+    @Test
+    fun `'starcoder auth token' option is present on settings`() {
+        every { settings.authToken } returns "abx34"
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JTextField>(settings::authToken.name)
+
+        assertThat(checkBox.text).isEqualTo("abx34")
+
+        checkBox.text = "xxfg54"
+        configurableSettings.apply()
+
+        verify { settings.authToken = "xxfg54" }
+    }
+
+    @Test
+    fun `'project package' option is present on settings`() {
+        every { settings.projectPackage } returns "initial"
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JTextField>(settings::projectPackage.name)
+
+        assertThat(checkBox.text).isEqualTo("initial")
+
+        checkBox.text = "changed"
+        configurableSettings.apply()
+
+        verify { settings.projectPackage = "changed" }
+    }
+
+    @Test
+    fun `'starcoder model' option is present on settings`() {
+        every { settings.starcoderModel } returns "some"
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JTextField>(settings::starcoderModel.name)
+
+        assertThat(checkBox.text).isEqualTo("some")
+
+        checkBox.text = "super"
+        configurableSettings.apply()
+
+        verify { settings.starcoderModel = "super" }
+    }
+
+    @Test
+    fun `'max new tokens' option is present on settings`() {
+        every { settings.starcoderMaxNewTokens } returns 100
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JSlider>(settings::starcoderMaxNewTokens.name)
+
+        assertThat(checkBox.value).isEqualTo(100)
+
+        checkBox.value = 250
+        configurableSettings.apply()
+
+        verify { settings.starcoderMaxNewTokens = 250 }
+    }
+
+    @Test
+    fun `'temperature' option is present on settings`() {
+        every { settings.starcoderTemperature } returns 3f
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JTextField>(settings::starcoderTemperature.name)
+
+        assertThat(checkBox.text).isEqualTo("3")
+
+        checkBox.text = "2"
+        configurableSettings.apply()
+
+        verify { settings.starcoderTemperature = 2f }
+    }
+
+    @Test
+    fun `'do sample' option is present on settings`() {
+        every { settings.starcoderDoSample } returns true
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JCheckBox>(settings::starcoderDoSample.name)
+
+        assertThat(checkBox.isSelected).isTrue()
+
+        checkBox.isSelected = false
+        configurableSettings.apply()
+
+        verify { settings.starcoderDoSample = false }
+    }
+
+    @Test
+    fun `'use cache' option is present on settings`() {
+        every { settings.starcoderUseCache } returns true
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JCheckBox>(settings::starcoderUseCache.name)
+
+        assertThat(checkBox.isSelected).isTrue()
+
+        checkBox.isSelected = false
+        configurableSettings.apply()
+
+        verify { settings.starcoderUseCache = false }
+    }
+
+    @Test
+    fun `'add tests comment' option is present on settings`() {
+        every { settings.isAddTestCommentsBeforeGeneration } returns true
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JCheckBox>(settings::isAddTestCommentsBeforeGeneration.name)
+
+        assertThat(checkBox.isSelected).isTrue()
+
+        checkBox.isSelected = false
+        configurableSettings.apply()
+
+        verify { settings.isAddTestCommentsBeforeGeneration = false }
+    }
+
+    @Test
+    fun `'generation source' option is present on settings`() {
+        every { settings.isConfirmSourceBeforeGeneration } returns true
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JCheckBox>(settings::isConfirmSourceBeforeGeneration.name)
+
+        assertThat(checkBox.isSelected).isTrue()
+
+        checkBox.isSelected = false
+        configurableSettings.apply()
+
+        verify { settings.isConfirmSourceBeforeGeneration = false }
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/PipelineStepKtTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/PipelineStepKtTest.kt
@@ -1,0 +1,36 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline
+
+import com.google.common.truth.Truth.assertThat
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
+import dev.sunnyday.fusiontdd.fusiontddplugin.test.executeAndWait
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class PipelineStepKtTest {
+
+    @Test
+    fun `on retry, if error received, retry n times`() {
+        val counter = AtomicInteger()
+        val pipeLine = PipelineStep<Nothing?, Unit> { _, observer ->
+            counter.incrementAndGet()
+            observer.invoke(Result.failure(Error()))
+        }
+
+        pipeLine.retry(3).executeAndWait()
+
+        assertThat(counter.get()).isEqualTo(4)
+    }
+
+    @Test
+    fun `on retry, if pipeline cancelled, don't retry`() {
+        val counter = AtomicInteger()
+        val pipeLine = PipelineStep<Nothing?, Unit> { _, observer ->
+            counter.incrementAndGet()
+            observer.invoke(Result.failure(PipelineCancellationException()))
+        }
+
+        pipeLine.retry(3).executeAndWait()
+
+        assertThat(counter.get()).isEqualTo(1)
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStepTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStepTest.kt
@@ -1,0 +1,62 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import com.intellij.testFramework.runInEdtAndWait
+import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.CodeBlock
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifyGenerationSourceDialog
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings.FusionTDDSettings
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
+import dev.sunnyday.fusiontdd.fusiontddplugin.test.executeAndWait
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import org.junit.jupiter.api.Test
+
+class ConfirmGenerationSourcePipelineStepTest : LightJavaCodeInsightFixtureTestCase5() {
+
+    private val settings = mockk<FusionTDDSettings>()
+
+    override fun getTestDataPath(): String = "testdata"
+
+    @Test
+    fun `on execute, if modify is disabled in settings do nothing`() {
+        every { settings.isConfirmSourceBeforeGeneration } returns false
+
+        val source = CodeBlock("2 + 2")
+        val step = ConfirmGenerationSourcePipelineStep(settings)
+
+        val result = step.executeAndWait(source)
+
+        assertThat(result.getOrNull()).isEqualTo(source)
+    }
+
+    @Test
+    fun `on execute, show confirm dialog and get result from it`() = runInEdtAndWait {
+        mockkConstructor(ModifyGenerationSourceDialog::class) {
+            every { settings.isConfirmSourceBeforeGeneration } returns true
+            every { anyConstructed<ModifyGenerationSourceDialog>().showAndGet() } returns true
+            every { anyConstructed<ModifyGenerationSourceDialog>().getCodeBlock() } returns "3 * 3"
+
+            val step = ConfirmGenerationSourcePipelineStep(settings)
+
+            val result = step.executeAndWait(CodeBlock("2 + 2"))
+
+            assertThat(result.getOrNull()).isEqualTo(CodeBlock("3 * 3"))
+        }
+    }
+
+    @Test
+    fun `on execute, if confirm dialog cancelled, cancel pipeline`() = runInEdtAndWait {
+        mockkConstructor(ModifyGenerationSourceDialog::class) {
+            every { settings.isConfirmSourceBeforeGeneration } returns true
+            every { anyConstructed<ModifyGenerationSourceDialog>().showAndGet() } returns false
+
+            val step = ConfirmGenerationSourcePipelineStep(settings)
+
+            val result = step.executeAndWait(CodeBlock("2 + 2"))
+
+            assertThat(result.exceptionOrNull()).isInstanceOf(PipelineCancellationException::class.java)
+        }
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/test/JComponentExtensions.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/test/JComponentExtensions.kt
@@ -1,0 +1,29 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.test
+
+import java.awt.Component
+import java.awt.Container
+import kotlin.reflect.KClass
+
+inline fun <reified T : Component> Container.requireChildByName(name: String): T {
+    return requireNotNull(findChildByName<T>(name))
+}
+
+inline fun <reified T : Component> Container.findChildByName(name: String): T? {
+    return findChildByName(name, T::class)
+}
+
+@Suppress("UNCHECKED_CAST") // expected
+fun <T : Component> Container.findChildByName(name: String, klass: KClass<T>): T? {
+    return findChild { it.name == name && klass.isInstance(it) } as? T
+}
+
+fun Container.findChild(predicate: (Component) -> Boolean): Component? {
+    components.forEach { component ->
+        when {
+            predicate.invoke(component) -> return component
+            component is Container -> component.findChild(predicate)?.let { return it }
+        }
+    }
+
+    return null
+}


### PR DESCRIPTION
- Added a dialog to confirm (or modify) generation source before request.
- An option to show the dialog added to settings.
- Settings are covered with tests.