### PR TITLE
Add generation applying error handling option and improve pipelines

### DIFF
--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/domain/service/PipelineStepsFactoryService.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/domain/service/PipelineStepsFactoryService.kt
@@ -21,4 +21,6 @@ internal interface PipelineStepsFactoryService {
     fun generateCodeSuggestion(): PipelineStep<CodeBlock, GenerateCodeBlockResult>
 
     fun replaceFunctionBody(function: KtNamedFunction): PipelineStep<GenerateCodeBlockResult, KtNamedFunction>
+
+    fun fixGenerationResult(): PipelineStep<GenerateCodeBlockResult, GenerateCodeBlockResult>
 }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifySourceCodeDialog.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifySourceCodeDialog.kt
@@ -1,6 +1,7 @@
 package dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog
 
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.ui.dsl.builder.Align
@@ -9,10 +10,14 @@ import java.awt.Dimension
 import javax.swing.Action
 import javax.swing.JComponent
 
-internal class ModifyGenerationSourceDialog : DialogWrapper(true) {
+internal class ModifySourceCodeDialog : DialogWrapper(true) {
 
-    private val codeTextArea = JBTextArea().apply {
+    private val codeBlockTextArea = JBTextArea().apply {
         name = "codeArea"
+    }
+
+    private val descriptionLabel = JBLabel("This source will be used for generation:").apply {
+        name = "descriptionLabel"
     }
 
     init {
@@ -24,19 +29,23 @@ internal class ModifyGenerationSourceDialog : DialogWrapper(true) {
         return "dev.sunnyday.fusiontdd.fusiontddplugin.ConfirmGenerationSourceDialog"
     }
 
+    fun setDescription(text: String) {
+        descriptionLabel.text = text
+    }
+
     fun setCodeBlock(rawCode: String) {
-        codeTextArea.text = rawCode
+        codeBlockTextArea.text = rawCode
     }
 
     fun getCodeBlock(): String {
-        return codeTextArea.text
+        return codeBlockTextArea.text
     }
 
     override fun createCenterPanel(): JComponent {
         return panel {
-            row { label("This source will be used for generation:") }
+            row { cell(descriptionLabel) }
             row {
-                cell(JBScrollPane(codeTextArea))
+                cell(JBScrollPane(codeBlockTextArea))
                     .applyToComponent { preferredSize = Dimension(800, 600) }
                     .align(Align.FILL)
             }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryService.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryService.kt
@@ -7,6 +7,7 @@ import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.CodeBlock
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.FunctionGenerationContext
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.GenerateCodeBlockResult
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.service.PipelineStepsFactoryService
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifySourceCodeDialog
 import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.PipelineStep
 import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.*
 import org.jetbrains.kotlin.psi.KtClass
@@ -37,6 +38,7 @@ internal class ProjectPipelineStepsFactoryService(
     override fun confirmGenerationSource(): PipelineStep<CodeBlock, CodeBlock> {
         return ConfirmGenerationSourcePipelineStep(
             settings = project.service(),
+            dialogFactory = ::ModifySourceCodeDialog,
         )
     }
 
@@ -50,5 +52,9 @@ internal class ProjectPipelineStepsFactoryService(
 
     override fun replaceFunctionBody(function: KtNamedFunction): PipelineStep<GenerateCodeBlockResult, KtNamedFunction> {
         return ReplaceFunctionBodyPipelineStep(function)
+    }
+
+    override fun fixGenerationResult(): PipelineStep<GenerateCodeBlockResult, GenerateCodeBlockResult> {
+        return FixGenerationResultPipelineStep(::ModifySourceCodeDialog)
     }
 }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettings.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettings.kt
@@ -26,6 +26,8 @@ internal class FusionTDDSettings : SimplePersistentStateComponent<FusionTDDSetti
     var starcoderWaitForModel by state::starcoderWaitForModel
 
     var isConfirmSourceBeforeGeneration by state::isConfirmSourceBeforeGeneration
+
+    var isFixApplyGenerationResultError by state::isFixApplyGenerationResultError
 }
 
 internal class FusionTDDSettingsState : BaseState() {
@@ -49,4 +51,6 @@ internal class FusionTDDSettingsState : BaseState() {
     var starcoderWaitForModel by property(true)
 
     var isConfirmSourceBeforeGeneration by property(false)
+
+    var isFixApplyGenerationResultError by property(true)
 }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProvider.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProvider.kt
@@ -151,6 +151,16 @@ internal class FusionTTDSettingsConfigurable(
                         )
                         .bindSelected(settings::isConfirmSourceBeforeGeneration)
                 }
+
+                row {
+                    checkBox("Handle apply generated suggestion error")
+                        .applyToComponent { name = settings::isFixApplyGenerationResultError.name }
+                        .comment(
+                            comment = "If enabled, the dialog with failed suggestion will be shown " +
+                                    "to allow fix/modify the suggestion and retry.",
+                        )
+                        .bindSelected(settings::isFixApplyGenerationResultError)
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/network/KtorClientFactory.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/network/KtorClientFactory.kt
@@ -8,18 +8,21 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 internal object KtorClientFactory {
 
-    fun createClient(authTokenProvider: AuthTokenProvider? = null): HttpClient {
+    fun createClient(authTokenProvider: AuthTokenProvider): HttpClient {
         return HttpClient(OkHttp) {
             engine {
                 config {
                     followRedirects(false)
 
-                    if (authTokenProvider != null) {
-                        addInterceptor(BearerAuthInterceptor(authTokenProvider))
-                    }
+                    connectTimeout(1.minutes.toJavaDuration())
+                    readTimeout(1.minutes.toJavaDuration())
+
+                    addInterceptor(BearerAuthInterceptor(authTokenProvider))
                 }
             }
 

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStep.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStep.kt
@@ -1,29 +1,28 @@
 package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps
 
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.CodeBlock
-import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifyGenerationSourceDialog
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifySourceCodeDialog
 import dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings.FusionTDDSettings
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.PipelineStep
-import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.common.ModifySourceCodePipelineStep
 
 internal class ConfirmGenerationSourcePipelineStep(
     private val settings: FusionTDDSettings,
-) : PipelineStep<CodeBlock, CodeBlock> {
+    dialogFactory: () -> ModifySourceCodeDialog,
+) : ModifySourceCodePipelineStep<CodeBlock>(dialogFactory) {
+
+    override fun getDialogCodeBlock(input: CodeBlock): String {
+        return input.rawText
+    }
+
+    override fun getModifiedInput(rawInput: String): CodeBlock {
+        return CodeBlock(rawInput)
+    }
 
     override fun execute(input: CodeBlock, observer: (Result<CodeBlock>) -> Unit) {
         if (!settings.isConfirmSourceBeforeGeneration) {
             observer.invoke(Result.success(input))
         } else {
-            val confirmDialog = ModifyGenerationSourceDialog().apply {
-                setCodeBlock(input.rawText)
-            }
-
-            if (confirmDialog.showAndGet()) {
-                val confirmedCodeBlock = CodeBlock(confirmDialog.getCodeBlock())
-                observer.invoke(Result.success(confirmedCodeBlock))
-            } else {
-                observer.invoke(Result.failure(PipelineCancellationException()))
-            }
+            super.execute(input, observer)
         }
     }
 }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/FixGenerationResultPipelineStep.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/FixGenerationResultPipelineStep.kt
@@ -1,0 +1,26 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps
+
+import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.CodeBlock
+import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.GenerateCodeBlockResult
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifySourceCodeDialog
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.common.ModifySourceCodePipelineStep
+
+internal class FixGenerationResultPipelineStep(
+    dialogFactory: () -> ModifySourceCodeDialog,
+) : ModifySourceCodePipelineStep<GenerateCodeBlockResult>(dialogFactory) {
+
+    override fun prepareDialog(dialog: ModifySourceCodeDialog) {
+        super.prepareDialog(dialog)
+
+        dialog.title = "Fix Generated Result"
+        dialog.setDescription("The generated result can't be applied to the function, fix it:")
+    }
+
+    override fun getDialogCodeBlock(input: GenerateCodeBlockResult): String {
+        return input.variants.firstOrNull()?.rawText.orEmpty()
+    }
+
+    override fun getModifiedInput(rawInput: String): GenerateCodeBlockResult {
+        return GenerateCodeBlockResult(variants = listOf(CodeBlock(rawInput)))
+    }
+}

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ReplaceFunctionBodyPipelineStep.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ReplaceFunctionBodyPipelineStep.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.util.Computable
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.GenerateCodeBlockResult
 import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.PipelineStep
-import org.jetbrains.kotlin.idea.util.reformatted
+import org.jetbrains.kotlin.idea.base.util.reformatted
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtPsiFactory
 
@@ -24,8 +24,9 @@ internal class ReplaceFunctionBodyPipelineStep(
                 Computable {
                     logger.debug("Pipeline: Replace function body of ${targetFunction.name}")
 
+                    val generatedBody = input.variants.firstOrNull()?.rawText.orEmpty()
                     KtPsiFactory(targetFunction.project, markGenerated = false)
-                        .createBlock(input.variants.firstOrNull()?.rawText.orEmpty())
+                        .createBlock(generatedBody)
                 }
             )
 

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/common/ModifySourceCodePipelineStep.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/common/ModifySourceCodePipelineStep.kt
@@ -1,0 +1,43 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps.common
+
+import com.intellij.util.application
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifySourceCodeDialog
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.PipelineStep
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
+
+internal abstract class ModifySourceCodePipelineStep<Input>(
+    private val dialogFactory: () -> ModifySourceCodeDialog,
+) : PipelineStep<Input, Input> {
+
+    protected abstract fun getDialogCodeBlock(input: Input): String
+
+    protected abstract fun getModifiedInput(rawInput: String): Input
+
+    protected open fun prepareDialog(dialog: ModifySourceCodeDialog) = Unit
+
+    override fun execute(input: Input, observer: (Result<Input>) -> Unit) = application.invokeAndWait {
+        val result = runCatching { modifyInputByModifyDialog(input) }
+        observer.invoke(result)
+    }
+
+    private fun modifyInputByModifyDialog(input: Input): Input {
+        val dialog = getModifyResultDialog(input)
+        prepareDialog(dialog)
+
+        if (!dialog.showAndGet()) {
+            throw PipelineCancellationException()
+        }
+
+        return getModifiedInput(dialog)
+    }
+
+    private fun getModifyResultDialog(input: Input): ModifySourceCodeDialog {
+        return dialogFactory.invoke().apply {
+            setCodeBlock(getDialogCodeBlock(input))
+        }
+    }
+
+    private fun getModifiedInput(dialog: ModifySourceCodeDialog): Input {
+        return getModifiedInput(dialog.getCodeBlock())
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/domain/util/EitherKtTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/domain/util/EitherKtTest.kt
@@ -1,0 +1,79 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.domain.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class EitherKtTest {
+
+    @Test
+    fun `on get left if value exists, returns left value`() {
+        val leftValue = "left"
+        val either = Either.Left(leftValue)
+
+        val actualValue = either.getLeftOrNull()
+
+        assertThat(actualValue).isEqualTo(leftValue)
+    }
+
+    @Test
+    fun `on get left if value no exists, returns null`() {
+        val either: Either<Int, String> = Either.Right("right")
+
+        val actualValue = either.getLeftOrNull()
+
+        assertThat(actualValue).isNull()
+    }
+
+    @Test
+    fun `on get right if value exists, returns right value`() {
+        val rightValue = "right"
+        val either = Either.Right(rightValue)
+
+        val actualValue = either.getRightOrNull()
+
+        assertThat(actualValue).isEqualTo(rightValue)
+    }
+
+    @Test
+    fun `on get right if value no exists, returns null`() {
+        val either: Either<String, Int> = Either.Left("left")
+
+        val actualValue = either.getRightOrNull()
+
+        assertThat(actualValue).isNull()
+    }
+
+    @Test
+    fun `on require right if left value exists, returns left value`() {
+        val rightValue = "right"
+        val either = Either.Right(rightValue)
+
+        val actualValue = either.requireRight()
+
+        assertThat(actualValue).isEqualTo(rightValue)
+    }
+
+    @Test
+    fun `on isLeft if is Either_Left, returns true`() {
+        val either = Either.Left("left")
+        assertThat(either.isLeft).isTrue()
+    }
+
+    @Test
+    fun `on isLeft if is Either_Right, returns false`() {
+        val either = Either.Right("right")
+        assertThat(either.isLeft).isFalse()
+    }
+
+    @Test
+    fun `on isRight if is Either_Right, returns true`() {
+        val either = Either.Right("right")
+        assertThat(either.isRight).isTrue()
+    }
+
+    @Test
+    fun `on isRight if is Either_Left, returns false`() {
+        val either = Either.Left("left")
+        assertThat(either.isRight).isFalse()
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifySourceCodeDialogTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/dialog/ModifySourceCodeDialogTest.kt
@@ -18,9 +18,11 @@ import io.mockk.spyk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JTextArea
 import kotlin.properties.Delegates
 
-class ModifyGenerationSourceDialogTest : LightJavaCodeInsightFixtureTestCase5() {
+class ModifySourceCodeDialogTest : LightJavaCodeInsightFixtureTestCase5() {
 
     private val contentPaneSlot = CapturingSlot<JComponent>()
     private var originalPeerFactory: DialogWrapperPeerFactory by Delegates.notNull()
@@ -47,24 +49,33 @@ class ModifyGenerationSourceDialogTest : LightJavaCodeInsightFixtureTestCase5() 
 
     @Test
     fun `dialog has dimensions service key`() = runInEdtAndWait {
-        val dialog = ModifyGenerationSourceDialog()
+        val dialog = ModifySourceCodeDialog()
         assertThat(dialog.dimensionKey).isNotEmpty()
     }
 
     @Test
     fun `on set code block, fill code area`() = runInEdtAndWait {
-        val dialog = ModifyGenerationSourceDialog()
+        val dialog = ModifySourceCodeDialog()
         dialog.setCodeBlock(rawCode = "2 + 2")
 
-        val textArea = contentPaneSlot.captured.requireChildByName<JBTextArea>("codeArea")
+        val textArea = contentPaneSlot.captured.requireChildByName<JTextArea>("codeArea")
 
         assertThat(textArea.text).isEqualTo("2 + 2")
     }
 
+    @Test
+    fun `on set description, update description label`() = runInEdtAndWait {
+        val dialog = ModifySourceCodeDialog()
+        dialog.setDescription("Changed description")
+
+        val textArea = contentPaneSlot.captured.requireChildByName<JLabel>("descriptionLabel")
+
+        assertThat(textArea.text).isEqualTo("Changed description")
+    }
 
     @Test
     fun `on get code block, get it from code area`() = runInEdtAndWait {
-        val dialog = ModifyGenerationSourceDialog()
+        val dialog = ModifySourceCodeDialog()
         dialog.setCodeBlock(rawCode = "2 + 2")
 
         val textArea = contentPaneSlot.captured.requireChildByName<JBTextArea>("codeArea")

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryServiceTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/service/ProjectPipelineStepsFactoryServiceTest.kt
@@ -59,4 +59,11 @@ class ProjectPipelineStepsFactoryServiceTest : LightJavaCodeInsightFixtureTestCa
 
         assertThat(actualStep).isInstanceOf(ReplaceFunctionBodyPipelineStep::class.java)
     }
+
+    @Test
+    fun `create step for fixGenerationResult`() {
+        val actualStep = provider.fixGenerationResult()
+
+        assertThat(actualStep).isInstanceOf(FixGenerationResultPipelineStep::class.java)
+    }
 }

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProviderTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProviderTest.kt
@@ -145,7 +145,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
     }
 
     @Test
-    fun `'generation source' option is present on settings`() {
+    fun `'show generation source' option is present on settings`() {
         every { settings.isConfirmSourceBeforeGeneration } returns true
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
@@ -157,5 +157,20 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         configurableSettings.apply()
 
         verify { settings.isConfirmSourceBeforeGeneration = false }
+    }
+
+    @Test
+    fun `'handle apply suggestion error' option is present on settings`() {
+        every { settings.isFixApplyGenerationResultError } returns true
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val checkBox = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JCheckBox>(settings::isFixApplyGenerationResultError.name)
+
+        assertThat(checkBox.isSelected).isTrue()
+
+        checkBox.isSelected = false
+        configurableSettings.apply()
+
+        verify { settings.isFixApplyGenerationResultError = false }
     }
 }

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStepTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/ConfirmGenerationSourcePipelineStepTest.kt
@@ -4,18 +4,18 @@ import com.google.common.truth.Truth.assertThat
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
 import com.intellij.testFramework.runInEdtAndWait
 import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.CodeBlock
-import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifyGenerationSourceDialog
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifySourceCodeDialog
 import dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings.FusionTDDSettings
 import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
 import dev.sunnyday.fusiontdd.fusiontddplugin.test.executeAndWait
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
 import org.junit.jupiter.api.Test
 
 class ConfirmGenerationSourcePipelineStepTest : LightJavaCodeInsightFixtureTestCase5() {
 
     private val settings = mockk<FusionTDDSettings>()
+    private val dialog = mockk<ModifySourceCodeDialog>(relaxed = true)
 
     override fun getTestDataPath(): String = "testdata"
 
@@ -24,7 +24,7 @@ class ConfirmGenerationSourcePipelineStepTest : LightJavaCodeInsightFixtureTestC
         every { settings.isConfirmSourceBeforeGeneration } returns false
 
         val source = CodeBlock("2 + 2")
-        val step = ConfirmGenerationSourcePipelineStep(settings)
+        val step = ConfirmGenerationSourcePipelineStep(settings, ::dialog)
 
         val result = step.executeAndWait(source)
 
@@ -33,30 +33,26 @@ class ConfirmGenerationSourcePipelineStepTest : LightJavaCodeInsightFixtureTestC
 
     @Test
     fun `on execute, show confirm dialog and get result from it`() = runInEdtAndWait {
-        mockkConstructor(ModifyGenerationSourceDialog::class) {
-            every { settings.isConfirmSourceBeforeGeneration } returns true
-            every { anyConstructed<ModifyGenerationSourceDialog>().showAndGet() } returns true
-            every { anyConstructed<ModifyGenerationSourceDialog>().getCodeBlock() } returns "3 * 3"
+        every { settings.isConfirmSourceBeforeGeneration } returns true
+        every { dialog.showAndGet() } returns true
+        every { dialog.getCodeBlock() } returns "3 * 3"
 
-            val step = ConfirmGenerationSourcePipelineStep(settings)
+        val step = ConfirmGenerationSourcePipelineStep(settings, ::dialog)
 
-            val result = step.executeAndWait(CodeBlock("2 + 2"))
+        val result = step.executeAndWait(CodeBlock("2 + 2"))
 
-            assertThat(result.getOrNull()).isEqualTo(CodeBlock("3 * 3"))
-        }
+        assertThat(result.getOrNull()).isEqualTo(CodeBlock("3 * 3"))
     }
 
     @Test
     fun `on execute, if confirm dialog cancelled, cancel pipeline`() = runInEdtAndWait {
-        mockkConstructor(ModifyGenerationSourceDialog::class) {
-            every { settings.isConfirmSourceBeforeGeneration } returns true
-            every { anyConstructed<ModifyGenerationSourceDialog>().showAndGet() } returns false
+        every { settings.isConfirmSourceBeforeGeneration } returns true
+        every { dialog.showAndGet() } returns false
 
-            val step = ConfirmGenerationSourcePipelineStep(settings)
+        val step = ConfirmGenerationSourcePipelineStep(settings, ::dialog)
 
-            val result = step.executeAndWait(CodeBlock("2 + 2"))
+        val result = step.executeAndWait(CodeBlock("2 + 2"))
 
-            assertThat(result.exceptionOrNull()).isInstanceOf(PipelineCancellationException::class.java)
-        }
+        assertThat(result.exceptionOrNull()).isInstanceOf(PipelineCancellationException::class.java)
     }
 }

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/FixGenerationResultPipelineStepTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/FixGenerationResultPipelineStepTest.kt
@@ -1,0 +1,112 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.steps
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.CodeBlock
+import dev.sunnyday.fusiontdd.fusiontddplugin.domain.model.GenerateCodeBlockResult
+import dev.sunnyday.fusiontdd.fusiontddplugin.idea.dialog.ModifySourceCodeDialog
+import dev.sunnyday.fusiontdd.fusiontddplugin.pipeline.util.PipelineCancellationException
+import dev.sunnyday.fusiontdd.fusiontddplugin.test.emptyObserver
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+
+class FixGenerationResultPipelineStepTest : LightJavaCodeInsightFixtureTestCase5() {
+
+    override fun getTestDataPath() = "testdata"
+
+    @Test
+    fun `on execute, show dialog with proper title and description`() {
+        // arrange
+        val modifyDialog = mockk<ModifySourceCodeDialog>(relaxed = true)
+        val step = createStep(modifyDialog)
+
+        // act
+        step.execute(createResult(""), emptyObserver())
+
+        // assert
+        verify {
+            modifyDialog.title = "Fix Generated Result"
+            modifyDialog.setDescription("The generated result can't be applied to the function, fix it:")
+        }
+    }
+
+    @Test
+    fun `on execute, show fix dialog with code as input`() {
+        // arrange
+        val modifyDialog = mockk<ModifySourceCodeDialog>(relaxed = true)
+        val step = createStep(modifyDialog)
+
+        // act
+        step.execute(createResult("broken code"), emptyObserver())
+
+        // assert
+        verify {
+            // that shown
+            modifyDialog.showAndGet()
+            // with correct code block
+            modifyDialog.setCodeBlock("broken code")
+        }
+    }
+
+    @Test
+    fun `on execute with empty variants, show fix dialog with empty input`() {
+        // arrange
+        val modifyDialog = mockk<ModifySourceCodeDialog>(relaxed = true)
+        val step = createStep(modifyDialog)
+
+        // act
+        step.execute(GenerateCodeBlockResult(emptyList()), emptyObserver())
+
+        // assert
+        // that shown
+        verify { modifyDialog.showAndGet() }
+        // with correct input
+        verify { modifyDialog.setCodeBlock("") }
+    }
+
+    @Test
+    fun `on dialog ok, use current input as result`() {
+        // arrange
+        val modifyDialog = mockk<ModifySourceCodeDialog>(relaxed = true) {
+            every { showAndGet() } returns true
+            every { getCodeBlock() } returns "modified code"
+        }
+        val step = createStep(modifyDialog)
+        val futureResult = CompletableFuture<Result<GenerateCodeBlockResult>>()
+
+        // act
+        step.execute(createResult(), futureResult::complete)
+        val result = futureResult.get()
+
+        // assert
+        assertThat(result.getOrNull()).isEqualTo(createResult("modified code"))
+    }
+
+    @Test
+    fun `on dialog cancel, use cancellation as result`() {
+        // arrange
+        val modifyDialog = mockk<ModifySourceCodeDialog>(relaxed = true) {
+            every { showAndGet() } returns false
+        }
+        val step = createStep(modifyDialog)
+        val futureResult = CompletableFuture<Result<GenerateCodeBlockResult>>()
+
+        // act
+        step.execute(createResult(), futureResult::complete)
+        val result = futureResult.get()
+
+        // assert
+        assertThat(result.exceptionOrNull()).isInstanceOf(PipelineCancellationException::class.java)
+    }
+
+    private fun createStep(dialog: ModifySourceCodeDialog): FixGenerationResultPipelineStep {
+        return FixGenerationResultPipelineStep { dialog }
+    }
+
+    private fun createResult(code: String = "some code"): GenerateCodeBlockResult {
+        return GenerateCodeBlockResult(listOf(CodeBlock(code)))
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/test/PipelineUtils.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/test/PipelineUtils.kt
@@ -1,0 +1,3 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.test
+
+fun <T> emptyObserver(): (Result<T>) -> Unit = {}


### PR DESCRIPTION
An option is added to the settings to allow handling of generation result applying errors.

The committed changes also improve the structure and readability of the code generation pipeline. Now, it's easier to follow what's happening during code generation process, improving maintainability significantly.

The modification logic for source code during the pipeline process is abstracted as well.