### PR TITLE
Handle functions without body in code generation

### DIFF
--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/PrepareGenerationSourceCodePipelineStep.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/PrepareGenerationSourceCodePipelineStep.kt
@@ -167,10 +167,10 @@ internal class PrepareGenerationSourceCodePipelineStep(
             }
 
             else -> {
-                if (declaration == input.targetFunction) {
-                    printTargetFunction(input.targetFunction, input)
-                } else {
-                    printFilterableElement(declaration, input)
+                when {
+                    declaration == input.targetFunction -> printTargetFunction(input.targetFunction, input)
+                    declaration is KtNamedFunction && !declaration.hasBody() -> printNoBodyFunction(declaration)
+                    else -> printFilterableElement(declaration, input)
                 }
             }
         }
@@ -251,6 +251,11 @@ internal class PrepareGenerationSourceCodePipelineStep(
 
         append(functionElement.rBrace?.getPreviousWhiteSpaceIndent().orEmpty())
         appendLine(functionElement.rBrace?.text.orEmpty())
+    }
+
+    private fun StringBuilder.printNoBodyFunction(function: KtNamedFunction) {
+        append("abstract ")
+        appendLine(function.text)
     }
 
     private fun StringBuilder.printFilterableElement(

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/PrepareGenerationSourceCodePipelineStepTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/pipeline/steps/PrepareGenerationSourceCodePipelineStepTest.kt
@@ -299,6 +299,32 @@ internal class PrepareGenerationSourceCodePipelineStepTest : LightJavaCodeInsigh
         )
     }
 
+    @Test
+    fun `on function without body, add abstract modifier`() {
+        executePrepareGenerationSourceCodeTest(
+            prepareFixture = {
+                addFileToProject(
+                    "Target.kt",
+                    """
+                        class Target {
+                
+                            private fun target(): Int
+                        }
+                    """.trimIndent(),
+                )
+            },
+            buildContext = simpleClassContextBuilder("Target") {
+                setUsedReferences(getClassFunction("Target.target"))
+            },
+            expectedOutput = """
+                class Target {
+                
+                    abstract private fun target(): Int
+                }
+            """.trimIndent(),
+        )
+    }
+
     // endregion
 
     // endregion
@@ -341,8 +367,8 @@ internal class PrepareGenerationSourceCodePipelineStepTest : LightJavaCodeInsigh
                     """
                         data class Some<T>(val value: T) {
                             companion object {
-                                fun createInt(value: Int): Some<Int>
-                                fun createOther(value: String): Some<String>
+                                fun createInt(value: Int): Some<Int> = TODO()
+                                fun createOther(value: String): Some<String> = TODO()
                             }
                         }
                     """.trimIndent(),
@@ -359,7 +385,7 @@ internal class PrepareGenerationSourceCodePipelineStepTest : LightJavaCodeInsigh
                 
                     companion object {
                 
-                        fun createInt(value: Int): Some<Int>
+                        fun createInt(value: Int): Some<Int> = TODO()
                     }
                 }
             """.trimIndent(),


### PR DESCRIPTION
This commit introduces handling for "no body" functions during the source code generation step. Now, these functions are tagged with an abstract modifier, allowing them to be correctly processed in subsequent stages. Corresponding tests have been added to validate this new feature.