### PR TITLE
Add additional prompts to FusionTDD plugin settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,8 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("io.mockk:mockk:1.13.8")
     testImplementation("com.google.truth:truth:1.1.5")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.2")
     testImplementation("io.ktor:ktor-client-mock:2.3.7")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.2")
 }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettings.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettings.kt
@@ -28,6 +28,10 @@ internal class FusionTDDSettings : SimplePersistentStateComponent<FusionTDDSetti
     var isConfirmSourceBeforeGeneration by state::isConfirmSourceBeforeGeneration
 
     var isFixApplyGenerationResultError by state::isFixApplyGenerationResultError
+
+    var globalAdditionalPrompt by state::globalAdditionalPrompt
+
+    var generationTargetAdditionalPrompt by state::generationTargetAdditionalPrompt
 }
 
 internal class FusionTDDSettingsState : BaseState() {
@@ -53,4 +57,8 @@ internal class FusionTDDSettingsState : BaseState() {
     var isConfirmSourceBeforeGeneration by property(false)
 
     var isFixApplyGenerationResultError by property(true)
+
+    var globalAdditionalPrompt by string("")
+
+    var generationTargetAdditionalPrompt by string("")
 }

--- a/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProvider.kt
+++ b/src/main/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProvider.kt
@@ -129,7 +129,9 @@ internal class FusionTTDSettingsConfigurable(
                         )
                         .bindSelected(settings::starcoderWaitForModel)
                 }
+            }
 
+            group("Prompts") {
                 row {
                     checkBox("Add tests comments before generation")
                         .applyToComponent { name = settings::isAddTestCommentsBeforeGeneration.name }
@@ -138,6 +140,30 @@ internal class FusionTTDSettingsConfigurable(
                                     "and places as a comment before the generating function.",
                         )
                         .bindSelected(settings::isAddTestCommentsBeforeGeneration)
+                }
+
+                row {
+                    textArea()
+                        .applyToComponent { name = settings::globalAdditionalPrompt.name }
+                        .label("Global additional prompt")
+                        .rows(3)
+                        .align(Align.FILL)
+                        .comment(
+                            comment = "This prompt will be added globally to the generation request.",
+                        )
+                        .bindText(settings::globalAdditionalPrompt.orEmpty(), settings::globalAdditionalPrompt::set)
+                }
+
+                row {
+                    textArea()
+                        .applyToComponent { name = settings::generationTargetAdditionalPrompt.name }
+                        .label("Generation target additional prompt")
+                        .rows(3)
+                        .align(Align.FILL)
+                        .comment(
+                            comment = "This prompt will as an additional comment to the generation target.",
+                        )
+                        .bindText(settings::generationTargetAdditionalPrompt.orEmpty(), settings::generationTargetAdditionalPrompt::set)
                 }
             }
 

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettingsTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettingsTest.kt
@@ -1,24 +1,11 @@
 package dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings
 
 import com.google.common.truth.Truth.assertThat
-import com.intellij.mock.MockApplication
-import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class FusionTDDSettingsTest {
-
-    private val testDisposable = object : Disposable.Default {}
-    private val application = MockApplication(testDisposable)
-
-    @BeforeEach
-    fun setUp() {
-        ApplicationManager.setApplication(application, testDisposable)
-    }
 
     @Test
     fun `provide authToken by state`() = testTDDSettings(
@@ -115,10 +102,5 @@ class FusionTDDSettingsTest {
         settings.loadState(state)
 
         settings.assert()
-    }
-
-    @AfterEach
-    fun tearDown() {
-        testDisposable.dispose()
     }
 }

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettingsTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTDDSettingsTest.kt
@@ -1,0 +1,124 @@
+package dev.sunnyday.fusiontdd.fusiontddplugin.idea.settings
+
+import com.google.common.truth.Truth.assertThat
+import com.intellij.mock.MockApplication
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class FusionTDDSettingsTest {
+
+    private val testDisposable = object : Disposable.Default {}
+    private val application = MockApplication(testDisposable)
+
+    @BeforeEach
+    fun setUp() {
+        ApplicationManager.setApplication(application, testDisposable)
+    }
+
+    @Test
+    fun `provide authToken by state`() = testTDDSettings(
+        prepareState = { authToken = "authToken" },
+        assert = { assertThat(authToken).isEqualTo(authToken) }
+    )
+
+    @Test
+    fun `provide projectPackage by state`() = testTDDSettings(
+        prepareState = { projectPackage = "projectPackage" },
+        assert = { assertThat(projectPackage).isEqualTo(projectPackage) }
+    )
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `provide isAddTestCommentsBeforeGeneration by state`(isEnabled: Boolean) = testTDDSettings(
+        prepareState = { isAddTestCommentsBeforeGeneration = isEnabled },
+        assert = { assertThat(isAddTestCommentsBeforeGeneration).isEqualTo(isAddTestCommentsBeforeGeneration) }
+    )
+
+    @Test
+    fun `provide starcoderModel by state`() = testTDDSettings(
+        prepareState = { starcoderModel = "starcoderModel" },
+        assert = { assertThat(starcoderModel).isEqualTo(starcoderModel) }
+    )
+
+    @Test
+    fun `provide starcoderMaxNewTokens by state`() = testTDDSettings(
+        prepareState = { starcoderMaxNewTokens = 154 },
+        assert = { assertThat(starcoderMaxNewTokens).isEqualTo(starcoderMaxNewTokens) }
+    )
+
+    @Test
+    fun `provide starcoderTemperature by state`() = testTDDSettings(
+        prepareState = { starcoderTemperature = 0.73f },
+        assert = { assertThat(starcoderTemperature).isEqualTo(starcoderTemperature) }
+    )
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `provide starcoderDoSample by state`(isEnabled: Boolean) = testTDDSettings(
+        prepareState = { starcoderDoSample = isEnabled },
+        assert = { assertThat(starcoderDoSample).isEqualTo(starcoderDoSample) }
+    )
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `provide starcoderUseCache by state`(isEnabled: Boolean) = testTDDSettings(
+        prepareState = { starcoderUseCache = isEnabled },
+        assert = { assertThat(starcoderUseCache).isEqualTo(starcoderUseCache) }
+    )
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `provide starcoderWaitForModel by state`(isEnabled: Boolean) = testTDDSettings(
+        prepareState = { starcoderWaitForModel = isEnabled },
+        assert = { assertThat(starcoderWaitForModel).isEqualTo(starcoderWaitForModel) }
+    )
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `provide isConfirmSourceBeforeGeneration by state`(isEnabled: Boolean) = testTDDSettings(
+        prepareState = { isConfirmSourceBeforeGeneration = isEnabled },
+        assert = { assertThat(isConfirmSourceBeforeGeneration).isEqualTo(isConfirmSourceBeforeGeneration) }
+    )
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `provide isFixApplyGenerationResultError by state`(isEnabled: Boolean) = testTDDSettings(
+        prepareState = { isFixApplyGenerationResultError = isEnabled },
+        assert = { assertThat(isFixApplyGenerationResultError).isEqualTo(isFixApplyGenerationResultError) }
+    )
+
+    @Test
+    fun `provide globalAdditionalPrompt by state`() = testTDDSettings(
+        prepareState = { globalAdditionalPrompt = "Global additional prompt" },
+        assert = { assertThat(globalAdditionalPrompt).isEqualTo(globalAdditionalPrompt) }
+    )
+
+    @Test
+    fun `provide generationTargetAdditionalPrompt by state`() = testTDDSettings(
+        prepareState = { generationTargetAdditionalPrompt = "Global additional prompt" },
+        assert = { assertThat(generationTargetAdditionalPrompt).isEqualTo(generationTargetAdditionalPrompt) }
+    )
+
+    private fun testTDDSettings(
+        prepareState: FusionTDDSettingsState.() -> Unit,
+        assert: FusionTDDSettings.() -> Unit,
+    ) {
+        val state = FusionTDDSettingsState()
+        state.prepareState()
+
+        val settings = FusionTDDSettings()
+        settings.loadState(state)
+
+        settings.assert()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        testDisposable.dispose()
+    }
+}

--- a/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProviderTest.kt
+++ b/src/test/kotlin/dev/sunnyday/fusiontdd/fusiontddplugin/idea/settings/FusionTTDSettingsConfigurableProviderTest.kt
@@ -9,9 +9,9 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import javax.swing.JCheckBox
 import javax.swing.JSlider
-import javax.swing.JTextField
+import javax.swing.JToggleButton
+import javax.swing.text.JTextComponent
 
 class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTestCase5() {
 
@@ -29,7 +29,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.authToken } returns "abx34"
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JTextField>(settings::authToken.name)
+            .requireChildByName<JTextComponent>(settings::authToken.name)
 
         assertThat(checkBox.text).isEqualTo("abx34")
 
@@ -44,7 +44,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.projectPackage } returns "initial"
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JTextField>(settings::projectPackage.name)
+            .requireChildByName<JTextComponent>(settings::projectPackage.name)
 
         assertThat(checkBox.text).isEqualTo("initial")
 
@@ -59,7 +59,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.starcoderModel } returns "some"
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JTextField>(settings::starcoderModel.name)
+            .requireChildByName<JTextComponent>(settings::starcoderModel.name)
 
         assertThat(checkBox.text).isEqualTo("some")
 
@@ -89,7 +89,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.starcoderTemperature } returns 3f
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JTextField>(settings::starcoderTemperature.name)
+            .requireChildByName<JTextComponent>(settings::starcoderTemperature.name)
 
         assertThat(checkBox.text).isEqualTo("3")
 
@@ -104,7 +104,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.starcoderDoSample } returns true
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JCheckBox>(settings::starcoderDoSample.name)
+            .requireChildByName<JToggleButton>(settings::starcoderDoSample.name)
 
         assertThat(checkBox.isSelected).isTrue()
 
@@ -119,7 +119,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.starcoderUseCache } returns true
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JCheckBox>(settings::starcoderUseCache.name)
+            .requireChildByName<JToggleButton>(settings::starcoderUseCache.name)
 
         assertThat(checkBox.isSelected).isTrue()
 
@@ -134,7 +134,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.isAddTestCommentsBeforeGeneration } returns true
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JCheckBox>(settings::isAddTestCommentsBeforeGeneration.name)
+            .requireChildByName<JToggleButton>(settings::isAddTestCommentsBeforeGeneration.name)
 
         assertThat(checkBox.isSelected).isTrue()
 
@@ -149,7 +149,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.isConfirmSourceBeforeGeneration } returns true
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JCheckBox>(settings::isConfirmSourceBeforeGeneration.name)
+            .requireChildByName<JToggleButton>(settings::isConfirmSourceBeforeGeneration.name)
 
         assertThat(checkBox.isSelected).isTrue()
 
@@ -164,7 +164,7 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         every { settings.isFixApplyGenerationResultError } returns true
         val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
         val checkBox = requireNotNull(configurableSettings.createComponent())
-            .requireChildByName<JCheckBox>(settings::isFixApplyGenerationResultError.name)
+            .requireChildByName<JToggleButton>(settings::isFixApplyGenerationResultError.name)
 
         assertThat(checkBox.isSelected).isTrue()
 
@@ -172,5 +172,35 @@ class FusionTTDSettingsConfigurableProviderTest : LightJavaCodeInsightFixtureTes
         configurableSettings.apply()
 
         verify { settings.isFixApplyGenerationResultError = false }
+    }
+
+    @Test
+    fun `global additional prompt field is present on settings`() {
+        every { settings.globalAdditionalPrompt } returns "globalAdditionalPrompt"
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val textField = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JTextComponent>(settings::globalAdditionalPrompt.name)
+
+        assertThat(textField.text).isEqualTo("globalAdditionalPrompt")
+
+        textField.text = "changed"
+        configurableSettings.apply()
+
+        verify { settings.globalAdditionalPrompt = "changed" }
+    }
+
+    @Test
+    fun `generation additional prompt field is present on settings`() {
+        every { settings.generationTargetAdditionalPrompt } returns "generationTargetAdditionalPrompt"
+        val configurableSettings = FusionTTDSettingsConfigurableProvider(fixture.project).createConfigurable()
+        val textField = requireNotNull(configurableSettings.createComponent())
+            .requireChildByName<JTextComponent>(settings::generationTargetAdditionalPrompt.name)
+
+        assertThat(textField.text).isEqualTo("generationTargetAdditionalPrompt")
+
+        textField.text = "changed"
+        configurableSettings.apply()
+
+        verify { settings.generationTargetAdditionalPrompt = "changed" }
     }
 }


### PR DESCRIPTION
This PR introduces two additional prompt settings to the FusionTDD plugin: globalAdditionalPrompt and generationTargetAdditionalPrompt. These prompts will be appended globally to the generation request and as an additional comment to the generation target respectively. Tests and configuration labels for these new fields have been added. Additionally, the Junit version was updated as part of this commit.